### PR TITLE
Add "Max Attempts" limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,12 +255,13 @@ karma start karma.conf.js
 The javascript library is extremely simple and heavily inspired by mixpanel. There are only five methods that a developer needs to understand. Beware that behind the scenes, the library maintains a queue backed by localStorage, buffers the events in the queue, and has a timer reguarly clear the queue. If the browser doesn't support localStorage, a in-memory queue will be created as EventHub is created. Also, our implementation relies on the server to track the timestamp of each event. Therefore, in the case of a browser session disconnected before all the events are sent, the remaining events will be sent in the next browser session and thus have the timestamp recorded as the next session starts.
 
 #### window.newEventHub()
-The method will create an EventHub and start the timer which clears out the event queue in every second (default)
+The method will create an EventHub, start the timer which clears out the event queue in every second and define a maximum attempts limit of 10 (default)
 ```javascript
 var name = "EventHub";
 var options = {
   url: 'http://example.com',
-  flushInterval: 10 /* in seconds */
+  flushInterval: 10 /* in seconds */,
+  maxAttempts: 10 /* Maxmimum attempts on failure */
 };
 var eventHub = window.newEventHub(name, options);
 ```

--- a/js/src/tracker.js
+++ b/js/src/tracker.js
@@ -74,13 +74,13 @@ window.DevTips=window.DevTips||{}; (function(dt){ var _2=0; var _3="Query string
     this.url = options.url || "";
     this.flushInterval = (options.flushInterval || 1) * 1000;
     this.maxAttempts = options.maxAttempts || 10;
-	  this.currentAttempts = 0;
+    this.currentAttempts = 0;
 
     this.sessionKey = name + "::activeSession";
     this.generatedIdKey = name + "::generatedId";
     this.identifiedUserKey = name + "::identifiedUser";
     this.generatedUserKey = name + "::generatedUser";
-    
+
     this.timeout = null;
   };
 
@@ -150,26 +150,26 @@ window.DevTips=window.DevTips||{}; (function(dt){ var _2=0; var _3="Query string
       var generatedId = this.localStorage.getObject(this.generatedIdKey);
 
       window.DevTips.jsonp(this.url + '/users/alias', {
-          from_external_user_id: params.id,
-          to_external_user_id: generatedId
-        }, "",
-        function(res) {
-	        success(res);
-	        this._resetFailures();
-        }.bind(this),
-  	    this._onFailure.bind(this));
-      };
-  
-    	this._resetFailures = function() {
-    	  this.currentAttempts = 0;
-    	};
-  
-      this._onFailure = function() {
-  	  if (++this.currentAttempts === this.maxAttempts) {
-  		  clearTimeout(this.timeout);
-  		  throw '"Max Attempts" limit has been reached'
-  	  }
-  	};
+        from_external_user_id: params.id,
+        to_external_user_id: generatedId
+      }, "",
+      function(res) {
+        success(res);
+        this._resetFailures();
+      }.bind(this),
+      this._onFailure.bind(this));
+    };
+
+    this._resetFailures = function() {
+      this.currentAttempts = 0;
+    };
+
+    this._onFailure = function() {
+      if (++this.currentAttempts === this.maxAttempts) {
+        clearTimeout(this.timeout);
+        throw '"Maximum Attempts" limit has been reached'
+      }
+    };
 
     this._setGeneratedUser = function(properties) {
       var generatedId = this.localStorage.getObject(this.generatedIdKey);
@@ -277,11 +277,11 @@ window.DevTips=window.DevTips||{}; (function(dt){ var _2=0; var _3="Query string
   window.newEventHub = function(name, options) {
     var storageQueue = new StorageQueue(name, window.localStorage || new FakeStorage());
     var eventHub = new EventHub(
-        name,
-        storageQueue,
-        window.localStorage || new FakeStorage(),
-        window.sessionStorage || new FakeStorage(),
-        options);
+      name,
+      storageQueue,
+      window.localStorage || new FakeStorage(),
+      window.sessionStorage || new FakeStorage(),
+      options);
 
     eventHub.initialize();
     eventHub.start();


### PR DESCRIPTION
Currently the client keep sending the events to the server if they have failed (because they never being removed from the queue), which cause the timeout function to run every X seconds, for infinite times.

maxAttempts is a configurable limit that clears the timeout function once the number of failed attempts (in a row) exceeds it.
